### PR TITLE
parse many parens for forloop

### DIFF
--- a/src/spinat/plsqlparser/Combinator.java
+++ b/src/spinat/plsqlparser/Combinator.java
@@ -224,6 +224,7 @@ public class Combinator {
                     if (rr2 == null) {
                         throw new ParseException("expecteing one more thing", rr.next);
                     }
+                    l.add(rr2.v);
                     s = rr2.next;
                 }
             }

--- a/src/spinat/plsqlparser/Parser.java
+++ b/src/spinat/plsqlparser/Parser.java
@@ -2011,9 +2011,10 @@ public class Parser {
         Res<Ast.Ident> rident = pIdent.pa(r.next);
         Res rin = pkw_in.pa(rident.next);
         {
-            Res resel = c.seq2(c.pPOpen, pkw_select).pa(rin.next);
+            Res<List<String>> reopen = c.many(c.pPOpen).pa(rin.next);
+            Res<String> resel = pkw_select.pa(reopen.next);
             if (resel == null) {
-                resel = c.seq2(c.pPOpen, pkw_with).pa(rin.next);
+                resel = pkw_with.pa(reopen.next);
             }
             if (resel != null) {
                 // skip the starting paren !

--- a/src/spinat/plsqlparser/T4.java
+++ b/src/spinat/plsqlparser/T4.java
@@ -16,6 +16,6 @@ public class T4<A, B, C, D> {
 
     @Override
     public String toString() {
-        return "<" + this.f1 + ", " + this.f2 + ", " + this.f3 + ">";
+        return "<" + this.f1 + ", " + this.f2 + ", " + this.f3 + ", " + this.f4 + ">";
     }
 }

--- a/test/spinat/plsqlparser/TestParser.java
+++ b/test/spinat/plsqlparser/TestParser.java
@@ -236,6 +236,15 @@ public class TestParser {
     }
 
     @Test
+    public void testForLoopManyParens() {
+        Parser p = new Parser();
+        tpa(p.pStatement, "for j in (select a,b,c from t1 union all select a,b,c from t2) loop null; end loop");
+        tpa(p.pStatement, "for j in ((select a,b,c from t1) union all select a,b,c from t2) loop null; end loop");
+        tpa(p.pStatement, "for j in (select a,b,c from t1 union all (select a,b,c from t2)) loop null; end loop");
+        tpa(p.pStatement, "for j in ((select a,b,c from t1 union all select a,b,c from t2)) loop null; end loop");
+    }
+    
+    @Test
     public void testTypeDeclaration() {
         Parser p = new Parser();
         tpa(p.pDeclaration, "subtype a is integer RANGE 1 .. 2");


### PR DESCRIPTION
Hi
I found one of my forloop statement has many parens in select expression, but the parser only handle one open paren. I create a pull request for Res<Ast.Statement> paForLoop(Seq s) in Parser and some testcases in testParser.

Thanks
Xu
